### PR TITLE
Fix the height of the authentication page being too large

### DIFF
--- a/apps/web/app/auth/page.tsx
+++ b/apps/web/app/auth/page.tsx
@@ -105,7 +105,7 @@ export default function AuthPage() {
   }, [code, authStatus]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-slate-50 dark:bg-slate-950/50">
+    <div className="flex-1 container py-8 flex flex-col items-center justify-center bg-slate-50 dark:bg-slate-950/50">
       <Card className="w-full max-w-md">
         <CardHeader>
           <CardTitle className="text-2xl font-bold text-center">


### PR DESCRIPTION
The height of the Modrinth authentication page now fills the screen height (leaving room for the footer), instead of setting the contents to the screen height, causing the footer to overflow.