### PR TITLE
Revert the removal of PGlite

### DIFF
--- a/apps/api/db/index.ts
+++ b/apps/api/db/index.ts
@@ -4,8 +4,8 @@ import { drizzle as drizzlePgLite } from "drizzle-orm/pglite";
 
 import { schema } from "./schema/schema";
 
-/**
-process.env.DEV_MODE === "true" &&
+const db =
+  process.env.DEV_MODE === "true" &&
   process.env.USE_PGLITE_DATABASE_CONNECTION === "true"
     ? (drizzlePgLite("./dist/pglite_database", {
         schema: schema,
@@ -13,10 +13,5 @@ process.env.DEV_MODE === "true" &&
     : drizzle(process.env.DATABASE_URL!, {
         schema: schema,
       });
-**/
-
-const db = drizzle(process.env.DATABASE_URL!, {
-  schema: schema
-});
 
 export default db;

--- a/apps/api/drizzle-dev.config.ts
+++ b/apps/api/drizzle-dev.config.ts
@@ -2,12 +2,23 @@ import "dotenv/config";
 import { defineConfig } from "drizzle-kit";
 
 export default defineConfig(
-  {
+  process.env.DEV_MODE === "true" &&
+    process.env.USE_PGLITE_DATABASE_CONNECTION === "true"
+    ? {
+        out: "./db/drizzle",
+        driver: "pglite",
+        schema: "./db/schema/schema.ts",
+        dialect: "postgresql",
+        dbCredentials: {
+          url: "./dist/pglite_database",
+        },
+      }
+    : {
         out: "./db/drizzle",
         schema: "./db/schema/schema.ts",
         dialect: "postgresql",
         dbCredentials: {
           url: process.env.DATABASE_URL!,
         },
-  }
+      },
 );


### PR DESCRIPTION
PGlite is not the issue. It's only in the folder name in error logs because it's installed, due to how PNPM names folders in `node_modules`.