### PR TITLE
ci: :green_heart: Disable Docker image publishing on bot branches

### DIFF
--- a/.github/workflows/build_and_publish_image.yml
+++ b/.github/workflows/build_and_publish_image.yml
@@ -1,8 +1,8 @@
 name: Build and Publish Loqui
 on:
     push:
-        branches:
-            - '**'
+        branches-ignore:
+            - 'dependabot/**'
         tags:
             - 'v*.*.*'
 


### PR DESCRIPTION
Disabled Docker image publishing on Dependabot's branches